### PR TITLE
change module info to work with grapefruit Juce 4.2

### DIFF
--- a/modules/SFZero/SFZero.cpp
+++ b/modules/SFZero/SFZero.cpp
@@ -2,5 +2,17 @@
 // and your header search path must make it accessible to the module's files.
 
 //#include "AppConfig.h"
-//#include "SFZero.h"
-
+#include "SFZero.h"
+#include "sfzero/RIFF.cpp" 
+#include "sfzero/SF2.cpp" 
+#include "sfzero/SF2Generator.cpp" 
+#include "sfzero/SF2Reader.cpp" 
+#include "sfzero/SF2Sound.cpp" 
+#include "sfzero/SFZDebug.cpp" 
+#include "sfzero/SFZEG.cpp" 
+#include "sfzero/SFZReader.cpp" 
+#include "sfzero/SFZRegion.cpp" 
+#include "sfzero/SFZSample.cpp" 
+#include "sfzero/SFZSound.cpp" 
+#include "sfzero/SFZSynth.cpp" 
+#include "sfzero/SFZVoice.cpp" 

--- a/modules/SFZero/SFZero.h
+++ b/modules/SFZero/SFZero.h
@@ -1,3 +1,16 @@
+/*
+BEGIN_JUCE_MODULE_DECLARATION
+    ID:               SFZero
+    vendor:           altalogix
+    version:          2.0.0
+    name:             SFZero sfz player
+    description:      SFZero .szf/.sf2 soundfont player; forked from https://github.com/stevefolta/SFZero and converted to Juce module by Leo Olivers
+    website:          https://github.com/altalogix/SFZero
+    dependencies:     juce_gui_basics, juce_audio_basics, juce_audio_processors
+	license:          MIT
+END_JUCE_MODULE_DECLARATION 
+*/
+
 #ifndef INCLUDED_SFZERO_H
 #define INCLUDED_SFZERO_H
 


### PR DESCRIPTION
I've just changed the format to work with the latest build of Juce. I haven't deleted juce_module_info, though it's now not used anymore. 

Thanks,
Loki
